### PR TITLE
docs: Move the 'Privacy Policy' link into the site footer

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,6 +2,7 @@
     <p>Copyright &copy; 2024 <a href="https://jbmorley.co.uk">Jason Morley</a></p>
     <nav>
         <ul>
+        <li><a href=="/privacy-policy/">Privacy Policy</a></li>
             <li><a href="/license/">License</a></li>
         </ul>
     </nav>

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -1,9 +1,8 @@
 <nav>
     <ul>
         <li>{% include link.html url="/" title=site.title %}</li>
-        <li>{% include link.html url="/support/" title="Support" %}</li>
         <li>{% include link.html url="/release-notes/" title="Release Notes" %}</li>
-        <li>{% include link.html url="/privacy-policy/" title="Privacy Policy" %}</li>
+        <li>{% include link.html url="/support/" title="Support" %}</li>
         <li><a target="_blank" href="https://github.com/inseven/thoughts">GitHub</a></li>
     </ul>
 </nav>


### PR DESCRIPTION
This change also switches the order of 'Support' and 'Release Notes'.