### PR TITLE
refactor: Use folders instead of groups in Xcode

### DIFF
--- a/Thoughts.xcodeproj/project.pbxproj
+++ b/Thoughts.xcodeproj/project.pbxproj
@@ -3,74 +3,19 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		D804FB112C081A2F004F8666 /* FrontmatterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D804FB102C081A2F004F8666 /* FrontmatterSwift */; };
-		D80E08A12B675AAC0023DD4F /* ComposeWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E08A02B675AAC0023DD4F /* ComposeWindow.swift */; };
-		D80E08A62B6761370023DD4F /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80E08A52B6761370023DD4F /* Document.swift */; };
-		D828CFF82BEECDDF00AC8E8B /* highlightedtexteditor-license in Resources */ = {isa = PBXBuildFile; fileRef = D86C389D2BEECDAA00248CD0 /* highlightedtexteditor-license */; };
-		D82ED7912C1924B100BC0BA8 /* PreviewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82ED7902C1924B100BC0BA8 /* PreviewModifier.swift */; };
-		D82ED7932C1935E700BC0BA8 /* EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82ED7922C1935E700BC0BA8 /* EdgeInsets.swift */; };
-		D82ED7962C19378500BC0BA8 /* SelectionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82ED7952C19378500BC0BA8 /* SelectionModifier.swift */; };
-		D83943E02C18FDDF00EB902E /* KeyboardPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83943DF2C18FDDF00EB902E /* KeyboardPreview.swift */; };
-		D83943E62C191ED900EB902E /* SymbolHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83943E52C191ED900EB902E /* SymbolHeader.swift */; };
-		D83943E82C191F3900EB902E /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83943E72C191F3900EB902E /* Page.swift */; };
-		D83943EA2C191FA900EB902E /* Pager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83943E92C191FA900EB902E /* Pager.swift */; };
-		D83943EC2C1920F200EB902E /* LocationPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83943EB2C1920F200EB902E /* LocationPreview.swift */; };
-		D83943EE2C1921F100EB902E /* FinderPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83943ED2C1921F100EB902E /* FinderPreview.swift */; };
-		D83C2F882B857B8C00CE60F7 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83C2F872B857B8C00CE60F7 /* URL.swift */; };
-		D83F58092C0968F300EF69D3 /* Trie.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F58082C0968F300EF69D3 /* Trie.swift */; };
-		D83F580B2C096EA300EF69D3 /* UTType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F580A2C096EA300EF69D3 /* UTType.swift */; };
-		D83F580D2C096F5A00EF69D3 /* TrieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83F580C2C096F5A00EF69D3 /* TrieTests.swift */; };
-		D84010C52BD74C760049715E /* yams-license in Resources */ = {isa = PBXBuildFile; fileRef = D84010C42BD74C760049715E /* yams-license */; };
-		D840967F2BD73CBE00926C85 /* LocationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = D840967E2BD73CBE00926C85 /* LocationDetails.swift */; };
-		D847E9332C1105A800FD6B63 /* AnyTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D847E9322C1105A800FD6B63 /* AnyTransition.swift */; };
-		D850C2D62B69D8D500338546 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D850C2D52B69D8D500338546 /* ContentView.swift */; };
-		D852AF022B6027CA00B77A3D /* ThoughtsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF012B6027CA00B77A3D /* ThoughtsApp.swift */; };
-		D852AF062B6027CC00B77A3D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D852AF052B6027CC00B77A3D /* Assets.xcassets */; };
-		D852AF092B6027CC00B77A3D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D852AF082B6027CC00B77A3D /* Preview Assets.xcassets */; };
-		D852AF142B6027CD00B77A3D /* RegionalDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF132B6027CD00B77A3D /* RegionalDateTests.swift */; };
-		D852AF1E2B6027CD00B77A3D /* ThoughtsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF1D2B6027CD00B77A3D /* ThoughtsUITests.swift */; };
-		D852AF202B6027CD00B77A3D /* ThoughtsUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF1F2B6027CD00B77A3D /* ThoughtsUITestsLaunchTests.swift */; };
-		D852AF642B604AF500B77A3D /* ApplicationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF632B604AF500B77A3D /* ApplicationModel.swift */; };
-		D852AF662B604B1200B77A3D /* ComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF652B604B1200B77A3D /* ComposeView.swift */; };
-		D852AF692B604B3E00B77A3D /* MainMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = D852AF682B604B3E00B77A3D /* MainMenu.swift */; };
 		D85FC1412BEEC3EC0004FAB3 /* TagField in Frameworks */ = {isa = PBXBuildFile; productRef = D85FC1402BEEC3EC0004FAB3 /* TagField */; };
-		D861B4072C0991CC00BA9B80 /* ThoughtsCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = D861B4062C0991CC00BA9B80 /* ThoughtsCommands.swift */; };
-		D86255842C091CF80044BD37 /* Library.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86255832C091CF80044BD37 /* Library.swift */; };
-		D86255862C09248D0044BD37 /* DirectoryScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86255852C09248D0044BD37 /* DirectoryScanner.swift */; };
 		D86255892C0924CD0044BD37 /* FSEventsWrapper in Frameworks */ = {isa = PBXBuildFile; productRef = D86255882C0924CD0044BD37 /* FSEventsWrapper */; };
-		D862558B2C0924ED0044BD37 /* fseventswrapper-license in Resources */ = {isa = PBXBuildFile; fileRef = D862558A2C0924ED0044BD37 /* fseventswrapper-license */; };
-		D862558D2C0925B40044BD37 /* Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = D862558C2C0925B40044BD37 /* Details.swift */; };
-		D862558F2C09262E0044BD37 /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D862558E2C09262E0044BD37 /* FileManager.swift */; };
-		D86255912C0926B40044BD37 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86255902C0926B40044BD37 /* Date.swift */; };
-		D876ABDB2BEC842800667F8E /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D876ABDA2BEC842800667F8E /* Sequence.swift */; };
 		D87707B52C01592400362786 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = D87707B42C01592400362786 /* HotKey */; };
 		D892249A2BD70CC300DA0932 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = D89224992BD70CC300DA0932 /* Yams */; };
-		D892249C2BD735A100DA0932 /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D892249B2BD735A100DA0932 /* Metadata.swift */; };
-		D892249E2BD735BE00DA0932 /* ThoughtsError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D892249D2BD735BE00DA0932 /* ThoughtsError.swift */; };
-		D89224A02BD735DA00DA0932 /* RegionalDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D892249F2BD735DA00DA0932 /* RegionalDate.swift */; };
-		D89224A22BD7365C00DA0932 /* TimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89224A12BD7365C00DA0932 /* TimeZone.swift */; };
-		D89224A42BD7368F00DA0932 /* TimeZoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89224A32BD7368F00DA0932 /* TimeZoneTests.swift */; };
-		D89224A72BD736B900DA0932 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89224A62BD736B900DA0932 /* Date.swift */; };
-		D89224A92BD736DF00DA0932 /* TimeZone.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89224A82BD736DF00DA0932 /* TimeZone.swift */; };
-		D8B1466D2C1290200063E81F /* MenuPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B1466C2C1290200063E81F /* MenuPreview.swift */; };
 		D8BA4D492BE59E16001A2A26 /* HighlightedTextEditor in Frameworks */ = {isa = PBXBuildFile; productRef = D8BA4D482BE59E16001A2A26 /* HighlightedTextEditor */; };
-		D8BA4D4D2BE5A9CB001A2A26 /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8BA4D4C2BE5A9CB001A2A26 /* SettingsWindow.swift */; };
 		D8C283E92BD9954F00161C82 /* HashRainbow in Frameworks */ = {isa = PBXBuildFile; productRef = D8C283E82BD9954F00161C82 /* HashRainbow */; };
-		D8CEE50A2C0A64FF00D2025A /* IntroductionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CEE5092C0A64FF00D2025A /* IntroductionView.swift */; };
-		D8CEE50C2C0A66FD00D2025A /* NSIntroductionWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CEE50B2C0A66FD00D2025A /* NSIntroductionWindow.swift */; };
-		D8CEE50E2C0A676900D2025A /* MarketingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CEE50D2C0A676900D2025A /* MarketingView.swift */; };
-		D8DFFCC82BD82DE900C9532A /* CLAuthorizationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DFFCC72BD82DE900C9532A /* CLAuthorizationStatus.swift */; };
-		D8E27EA42BD9EA53001EEE98 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E27EA32BD9EA53001EEE98 /* String.swift */; };
-		D8E27EA62BD9EB61001EEE98 /* Licensable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E27EA52BD9EB61001EEE98 /* Licensable.swift */; };
 		D8F06D4B2B67275B0039AEF4 /* Diligence in Frameworks */ = {isa = PBXBuildFile; productRef = D8F06D4A2B67275B0039AEF4 /* Diligence */; };
 		D8F06D4E2B6727630039AEF4 /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D8F06D4D2B6727630039AEF4 /* Interact */; };
-		D8F06D512B6731CE0039AEF4 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F06D502B6731CE0039AEF4 /* SettingsView.swift */; };
-		D8F06D542B6733650039AEF4 /* thoughts-license in Resources */ = {isa = PBXBuildFile; fileRef = D8F06D532B6733650039AEF4 /* thoughts-license */; };
-		D8F06D562B6734540039AEF4 /* material-icons-license in Resources */ = {isa = PBXBuildFile; fileRef = D8F06D552B6734540039AEF4 /* material-icons-license */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,67 +36,26 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		D80E089E2B674E900023DD4F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		D80E08A02B675AAC0023DD4F /* ComposeWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeWindow.swift; sourceTree = "<group>"; };
-		D80E08A52B6761370023DD4F /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
-		D82ED7902C1924B100BC0BA8 /* PreviewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewModifier.swift; sourceTree = "<group>"; };
-		D82ED7922C1935E700BC0BA8 /* EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeInsets.swift; sourceTree = "<group>"; };
-		D82ED7952C19378500BC0BA8 /* SelectionModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionModifier.swift; sourceTree = "<group>"; };
-		D83943DF2C18FDDF00EB902E /* KeyboardPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardPreview.swift; sourceTree = "<group>"; };
-		D83943E52C191ED900EB902E /* SymbolHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolHeader.swift; sourceTree = "<group>"; };
-		D83943E72C191F3900EB902E /* Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
-		D83943E92C191FA900EB902E /* Pager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pager.swift; sourceTree = "<group>"; };
-		D83943EB2C1920F200EB902E /* LocationPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPreview.swift; sourceTree = "<group>"; };
-		D83943ED2C1921F100EB902E /* FinderPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderPreview.swift; sourceTree = "<group>"; };
-		D83C2F872B857B8C00CE60F7 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
-		D83F58082C0968F300EF69D3 /* Trie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Trie.swift; sourceTree = "<group>"; };
-		D83F580A2C096EA300EF69D3 /* UTType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTType.swift; sourceTree = "<group>"; };
-		D83F580C2C096F5A00EF69D3 /* TrieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrieTests.swift; sourceTree = "<group>"; };
-		D84010C42BD74C760049715E /* yams-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "yams-license"; sourceTree = "<group>"; };
-		D840967E2BD73CBE00926C85 /* LocationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetails.swift; sourceTree = "<group>"; };
-		D847E9322C1105A800FD6B63 /* AnyTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTransition.swift; sourceTree = "<group>"; };
-		D850C2D52B69D8D500338546 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		D852AEFE2B6027CA00B77A3D /* Thoughts.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Thoughts.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		D852AF012B6027CA00B77A3D /* ThoughtsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtsApp.swift; sourceTree = "<group>"; };
-		D852AF052B6027CC00B77A3D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D852AF082B6027CC00B77A3D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		D852AF0A2B6027CC00B77A3D /* Thoughts.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Thoughts.entitlements; sourceTree = "<group>"; };
 		D852AF0F2B6027CD00B77A3D /* ThoughtsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThoughtsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D852AF132B6027CD00B77A3D /* RegionalDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionalDateTests.swift; sourceTree = "<group>"; };
 		D852AF192B6027CD00B77A3D /* ThoughtsUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThoughtsUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D852AF1D2B6027CD00B77A3D /* ThoughtsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtsUITests.swift; sourceTree = "<group>"; };
-		D852AF1F2B6027CD00B77A3D /* ThoughtsUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtsUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		D852AF632B604AF500B77A3D /* ApplicationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationModel.swift; sourceTree = "<group>"; };
-		D852AF652B604B1200B77A3D /* ComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposeView.swift; sourceTree = "<group>"; };
-		D852AF682B604B3E00B77A3D /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
-		D861B4062C0991CC00BA9B80 /* ThoughtsCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtsCommands.swift; sourceTree = "<group>"; };
-		D86255832C091CF80044BD37 /* Library.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Library.swift; sourceTree = "<group>"; };
-		D86255852C09248D0044BD37 /* DirectoryScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectoryScanner.swift; sourceTree = "<group>"; };
-		D862558A2C0924ED0044BD37 /* fseventswrapper-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "fseventswrapper-license"; sourceTree = "<group>"; };
-		D862558C2C0925B40044BD37 /* Details.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Details.swift; sourceTree = "<group>"; };
-		D862558E2C09262E0044BD37 /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
-		D86255902C0926B40044BD37 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
-		D86C389D2BEECDAA00248CD0 /* highlightedtexteditor-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "highlightedtexteditor-license"; sourceTree = "<group>"; };
-		D876ABDA2BEC842800667F8E /* Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
-		D892249B2BD735A100DA0932 /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
-		D892249D2BD735BE00DA0932 /* ThoughtsError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThoughtsError.swift; sourceTree = "<group>"; };
-		D892249F2BD735DA00DA0932 /* RegionalDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionalDate.swift; sourceTree = "<group>"; };
-		D89224A12BD7365C00DA0932 /* TimeZone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZone.swift; sourceTree = "<group>"; };
-		D89224A32BD7368F00DA0932 /* TimeZoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneTests.swift; sourceTree = "<group>"; };
-		D89224A62BD736B900DA0932 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
-		D89224A82BD736DF00DA0932 /* TimeZone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZone.swift; sourceTree = "<group>"; };
-		D8B1466C2C1290200063E81F /* MenuPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuPreview.swift; sourceTree = "<group>"; };
-		D8BA4D4C2BE5A9CB001A2A26 /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
-		D8CEE5092C0A64FF00D2025A /* IntroductionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroductionView.swift; sourceTree = "<group>"; };
-		D8CEE50B2C0A66FD00D2025A /* NSIntroductionWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSIntroductionWindow.swift; sourceTree = "<group>"; };
-		D8CEE50D2C0A676900D2025A /* MarketingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketingView.swift; sourceTree = "<group>"; };
-		D8DFFCC72BD82DE900C9532A /* CLAuthorizationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLAuthorizationStatus.swift; sourceTree = "<group>"; };
-		D8E27EA32BD9EA53001EEE98 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
-		D8E27EA52BD9EB61001EEE98 /* Licensable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Licensable.swift; sourceTree = "<group>"; };
-		D8F06D502B6731CE0039AEF4 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		D8F06D532B6733650039AEF4 /* thoughts-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "thoughts-license"; sourceTree = "<group>"; };
-		D8F06D552B6734540039AEF4 /* material-icons-license */ = {isa = PBXFileReference; lastKnownFileType = text; path = "material-icons-license"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D8184AED2E1D27A200D46CE7 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = D852AEFD2B6027CA00B77A3D /* Thoughts */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		D8184A6F2E1D278900D46CE7 /* ThoughtsUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ThoughtsUITests; sourceTree = "<group>"; };
+		D8184A782E1D278C00D46CE7 /* ThoughtsTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ThoughtsTests; sourceTree = "<group>"; };
+		D8184ABB2E1D27A200D46CE7 /* Thoughts */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (D8184AED2E1D27A200D46CE7 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Thoughts; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		D852AEFB2B6027CA00B77A3D /* Frameworks */ = {
@@ -187,107 +91,12 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		D80E089F2B67572E0023DD4F /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				D852AF632B604AF500B77A3D /* ApplicationModel.swift */,
-				D80E08A52B6761370023DD4F /* Document.swift */,
-				D86255832C091CF80044BD37 /* Library.swift */,
-				D840967E2BD73CBE00926C85 /* LocationDetails.swift */,
-				D892249B2BD735A100DA0932 /* Metadata.swift */,
-				D892249F2BD735DA00DA0932 /* RegionalDate.swift */,
-				D892249D2BD735BE00DA0932 /* ThoughtsError.swift */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		D80E08A22B675AD40023DD4F /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				D847E9322C1105A800FD6B63 /* AnyTransition.swift */,
-				D8DFFCC72BD82DE900C9532A /* CLAuthorizationStatus.swift */,
-				D86255902C0926B40044BD37 /* Date.swift */,
-				D82ED7922C1935E700BC0BA8 /* EdgeInsets.swift */,
-				D862558E2C09262E0044BD37 /* FileManager.swift */,
-				D8E27EA52BD9EB61001EEE98 /* Licensable.swift */,
-				D876ABDA2BEC842800667F8E /* Sequence.swift */,
-				D8E27EA32BD9EA53001EEE98 /* String.swift */,
-				D89224A12BD7365C00DA0932 /* TimeZone.swift */,
-				D83C2F872B857B8C00CE60F7 /* URL.swift */,
-				D83F580A2C096EA300EF69D3 /* UTType.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		D82ED7942C19376000BC0BA8 /* Modifiers */ = {
-			isa = PBXGroup;
-			children = (
-				D82ED7902C1924B100BC0BA8 /* PreviewModifier.swift */,
-				D82ED7952C19378500BC0BA8 /* SelectionModifier.swift */,
-			);
-			path = Modifiers;
-			sourceTree = "<group>";
-		};
-		D83943E12C1910AA00EB902E /* Introduction */ = {
-			isa = PBXGroup;
-			children = (
-				D83943ED2C1921F100EB902E /* FinderPreview.swift */,
-				D8CEE5092C0A64FF00D2025A /* IntroductionView.swift */,
-				D83943DF2C18FDDF00EB902E /* KeyboardPreview.swift */,
-				D83943EB2C1920F200EB902E /* LocationPreview.swift */,
-				D8CEE50D2C0A676900D2025A /* MarketingView.swift */,
-				D8B1466C2C1290200063E81F /* MenuPreview.swift */,
-				D8CEE50B2C0A66FD00D2025A /* NSIntroductionWindow.swift */,
-				D83943E72C191F3900EB902E /* Page.swift */,
-				D83943E92C191FA900EB902E /* Pager.swift */,
-				D83943E52C191ED900EB902E /* SymbolHeader.swift */,
-			);
-			path = Introduction;
-			sourceTree = "<group>";
-		};
-		D83943E22C19189D00EB902E /* Compose */ = {
-			isa = PBXGroup;
-			children = (
-				D852AF652B604B1200B77A3D /* ComposeView.swift */,
-				D80E08A02B675AAC0023DD4F /* ComposeWindow.swift */,
-				D850C2D52B69D8D500338546 /* ContentView.swift */,
-			);
-			path = Compose;
-			sourceTree = "<group>";
-		};
-		D83943E32C1918B300EB902E /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				D8F06D502B6731CE0039AEF4 /* SettingsView.swift */,
-				D8BA4D4C2BE5A9CB001A2A26 /* SettingsWindow.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		D83943E42C19199C00EB902E /* Menu */ = {
-			isa = PBXGroup;
-			children = (
-				D852AF682B604B3E00B77A3D /* MainMenu.swift */,
-			);
-			path = Menu;
-			sourceTree = "<group>";
-		};
-		D83F58072C0968EA00EF69D3 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				D862558C2C0925B40044BD37 /* Details.swift */,
-				D86255852C09248D0044BD37 /* DirectoryScanner.swift */,
-				D83F58082C0968F300EF69D3 /* Trie.swift */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
 		D852AEF52B6027CA00B77A3D = {
 			isa = PBXGroup;
 			children = (
-				D852AF002B6027CA00B77A3D /* Thoughts */,
-				D852AF122B6027CD00B77A3D /* ThoughtsTests */,
-				D852AF1C2B6027CD00B77A3D /* ThoughtsUITests */,
+				D8184ABB2E1D27A200D46CE7 /* Thoughts */,
+				D8184A782E1D278C00D46CE7 /* ThoughtsTests */,
+				D8184A6F2E1D278900D46CE7 /* ThoughtsUITests */,
 				D852AEFF2B6027CA00B77A3D /* Products */,
 				D8C283EA2BD9955D00161C82 /* Frameworks */,
 			);
@@ -303,90 +112,11 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D852AF002B6027CA00B77A3D /* Thoughts */ = {
-			isa = PBXGroup;
-			children = (
-				D852AF0A2B6027CC00B77A3D /* Thoughts.entitlements */,
-				D80E089E2B674E900023DD4F /* Info.plist */,
-				D852AF012B6027CA00B77A3D /* ThoughtsApp.swift */,
-				D861B4062C0991CC00BA9B80 /* ThoughtsCommands.swift */,
-				D852AF052B6027CC00B77A3D /* Assets.xcassets */,
-				D80E08A22B675AD40023DD4F /* Extensions */,
-				D8F06D522B6733440039AEF4 /* Licenses */,
-				D80E089F2B67572E0023DD4F /* Model */,
-				D82ED7942C19376000BC0BA8 /* Modifiers */,
-				D852AF072B6027CC00B77A3D /* Preview Content */,
-				D83F58072C0968EA00EF69D3 /* Utilities */,
-				D8F06D4F2B6731C00039AEF4 /* Views */,
-			);
-			path = Thoughts;
-			sourceTree = "<group>";
-		};
-		D852AF072B6027CC00B77A3D /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				D852AF082B6027CC00B77A3D /* Preview Assets.xcassets */,
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		D852AF122B6027CD00B77A3D /* ThoughtsTests */ = {
-			isa = PBXGroup;
-			children = (
-				D89224A52BD736B000DA0932 /* Extensions */,
-				D852AF132B6027CD00B77A3D /* RegionalDateTests.swift */,
-				D89224A32BD7368F00DA0932 /* TimeZoneTests.swift */,
-				D83F580C2C096F5A00EF69D3 /* TrieTests.swift */,
-			);
-			path = ThoughtsTests;
-			sourceTree = "<group>";
-		};
-		D852AF1C2B6027CD00B77A3D /* ThoughtsUITests */ = {
-			isa = PBXGroup;
-			children = (
-				D852AF1D2B6027CD00B77A3D /* ThoughtsUITests.swift */,
-				D852AF1F2B6027CD00B77A3D /* ThoughtsUITestsLaunchTests.swift */,
-			);
-			path = ThoughtsUITests;
-			sourceTree = "<group>";
-		};
-		D89224A52BD736B000DA0932 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				D89224A62BD736B900DA0932 /* Date.swift */,
-				D89224A82BD736DF00DA0932 /* TimeZone.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
 		D8C283EA2BD9955D00161C82 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		D8F06D4F2B6731C00039AEF4 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				D83943E22C19189D00EB902E /* Compose */,
-				D83943E12C1910AA00EB902E /* Introduction */,
-				D83943E42C19199C00EB902E /* Menu */,
-				D83943E32C1918B300EB902E /* Settings */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		D8F06D522B6733440039AEF4 /* Licenses */ = {
-			isa = PBXGroup;
-			children = (
-				D862558A2C0924ED0044BD37 /* fseventswrapper-license */,
-				D86C389D2BEECDAA00248CD0 /* highlightedtexteditor-license */,
-				D8F06D552B6734540039AEF4 /* material-icons-license */,
-				D8F06D532B6733650039AEF4 /* thoughts-license */,
-				D84010C42BD74C760049715E /* yams-license */,
-			);
-			path = Licenses;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -403,6 +133,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				D8184ABB2E1D27A200D46CE7 /* Thoughts */,
 			);
 			name = Thoughts;
 			packageProductDependencies = (
@@ -433,6 +166,9 @@
 			dependencies = (
 				D852AF112B6027CD00B77A3D /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				D8184A782E1D278C00D46CE7 /* ThoughtsTests */,
+			);
 			name = ThoughtsTests;
 			productName = "Disk StickiesTests";
 			productReference = D852AF0F2B6027CD00B77A3D /* ThoughtsTests.xctest */;
@@ -450,6 +186,9 @@
 			);
 			dependencies = (
 				D852AF1B2B6027CD00B77A3D /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				D8184A6F2E1D278900D46CE7 /* ThoughtsUITests */,
 			);
 			name = ThoughtsUITests;
 			productName = "Disk StickiesUITests";
@@ -515,13 +254,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8F06D542B6733650039AEF4 /* thoughts-license in Resources */,
-				D852AF092B6027CC00B77A3D /* Preview Assets.xcassets in Resources */,
-				D8F06D562B6734540039AEF4 /* material-icons-license in Resources */,
-				D852AF062B6027CC00B77A3D /* Assets.xcassets in Resources */,
-				D84010C52BD74C760049715E /* yams-license in Resources */,
-				D862558B2C0924ED0044BD37 /* fseventswrapper-license in Resources */,
-				D828CFF82BEECDDF00AC8E8B /* highlightedtexteditor-license in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,47 +278,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D852AF642B604AF500B77A3D /* ApplicationModel.swift in Sources */,
-				D8CEE50A2C0A64FF00D2025A /* IntroductionView.swift in Sources */,
-				D8CEE50C2C0A66FD00D2025A /* NSIntroductionWindow.swift in Sources */,
-				D850C2D62B69D8D500338546 /* ContentView.swift in Sources */,
-				D840967F2BD73CBE00926C85 /* LocationDetails.swift in Sources */,
-				D8CEE50E2C0A676900D2025A /* MarketingView.swift in Sources */,
-				D8DFFCC82BD82DE900C9532A /* CLAuthorizationStatus.swift in Sources */,
-				D83943EC2C1920F200EB902E /* LocationPreview.swift in Sources */,
-				D852AF692B604B3E00B77A3D /* MainMenu.swift in Sources */,
-				D83C2F882B857B8C00CE60F7 /* URL.swift in Sources */,
-				D86255912C0926B40044BD37 /* Date.swift in Sources */,
-				D89224A02BD735DA00DA0932 /* RegionalDate.swift in Sources */,
-				D83943EA2C191FA900EB902E /* Pager.swift in Sources */,
-				D876ABDB2BEC842800667F8E /* Sequence.swift in Sources */,
-				D861B4072C0991CC00BA9B80 /* ThoughtsCommands.swift in Sources */,
-				D83F580B2C096EA300EF69D3 /* UTType.swift in Sources */,
-				D83943E82C191F3900EB902E /* Page.swift in Sources */,
-				D862558D2C0925B40044BD37 /* Details.swift in Sources */,
-				D86255842C091CF80044BD37 /* Library.swift in Sources */,
-				D86255862C09248D0044BD37 /* DirectoryScanner.swift in Sources */,
-				D82ED7932C1935E700BC0BA8 /* EdgeInsets.swift in Sources */,
-				D83943E02C18FDDF00EB902E /* KeyboardPreview.swift in Sources */,
-				D892249E2BD735BE00DA0932 /* ThoughtsError.swift in Sources */,
-				D8E27EA62BD9EB61001EEE98 /* Licensable.swift in Sources */,
-				D83F58092C0968F300EF69D3 /* Trie.swift in Sources */,
-				D852AF662B604B1200B77A3D /* ComposeView.swift in Sources */,
-				D82ED7962C19378500BC0BA8 /* SelectionModifier.swift in Sources */,
-				D862558F2C09262E0044BD37 /* FileManager.swift in Sources */,
-				D8BA4D4D2BE5A9CB001A2A26 /* SettingsWindow.swift in Sources */,
-				D8F06D512B6731CE0039AEF4 /* SettingsView.swift in Sources */,
-				D8E27EA42BD9EA53001EEE98 /* String.swift in Sources */,
-				D80E08A62B6761370023DD4F /* Document.swift in Sources */,
-				D8B1466D2C1290200063E81F /* MenuPreview.swift in Sources */,
-				D852AF022B6027CA00B77A3D /* ThoughtsApp.swift in Sources */,
-				D82ED7912C1924B100BC0BA8 /* PreviewModifier.swift in Sources */,
-				D83943EE2C1921F100EB902E /* FinderPreview.swift in Sources */,
-				D83943E62C191ED900EB902E /* SymbolHeader.swift in Sources */,
-				D80E08A12B675AAC0023DD4F /* ComposeWindow.swift in Sources */,
-				D847E9332C1105A800FD6B63 /* AnyTransition.swift in Sources */,
-				D89224A22BD7365C00DA0932 /* TimeZone.swift in Sources */,
-				D892249C2BD735A100DA0932 /* Metadata.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -594,11 +285,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D89224A92BD736DF00DA0932 /* TimeZone.swift in Sources */,
-				D83F580D2C096F5A00EF69D3 /* TrieTests.swift in Sources */,
-				D89224A42BD7368F00DA0932 /* TimeZoneTests.swift in Sources */,
-				D89224A72BD736B900DA0932 /* Date.swift in Sources */,
-				D852AF142B6027CD00B77A3D /* RegionalDateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -606,8 +292,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D852AF202B6027CD00B77A3D /* ThoughtsUITestsLaunchTests.swift in Sources */,
-				D852AF1E2B6027CD00B77A3D /* ThoughtsUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -822,7 +506,6 @@
 		D852AF272B6027CD00B77A3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -842,7 +525,6 @@
 		D852AF282B6027CD00B77A3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -862,7 +544,6 @@
 		D852AF2A2B6027CD00B77A3D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -880,7 +561,6 @@
 		D852AF2B2B6027CD00B77A3D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;


### PR DESCRIPTION
This should reduce the number of project file changes when making future updates.