### PR TITLE
fix: 🛑 Don't allow the settings window to be minimized

### DIFF
--- a/Thoughts/Views/Settings/SettingsWindow.swift
+++ b/Thoughts/Views/Settings/SettingsWindow.swift
@@ -29,6 +29,7 @@ struct SettingsWindow: Scene {
     var body: some Scene {
         Window("Thoughts Settings", id: Self.windowID) {
             SettingsView(applicationModel: applicationModel)
+                .minimizeDisabled()
         }
         .defaultPosition(.center)
         .windowResizability(.contentSize)


### PR DESCRIPTION
This brings the behaviour in-line with the rest of the macOS.