### PR TITLE
docs[website]: Simplify the release notes

### DIFF
--- a/scripts/release-notes.markdown
+++ b/scripts/release-notes.markdown
@@ -5,11 +5,9 @@ title: Releases
 # Releases
 
 {% for release in releases -%}
-## {{ release.version }}{% if not release.is_released %} (Unreleased){% endif %}
-{% for section in release.sections %}
-**{{ section.title }}**
-
+## {% if release.is_released %}<a href="https://github.com/inseven/thoughts/releases/tag/{{ release.version }}">{{ release.version }}</a>{% else %}{{ release.version }} (Unreleased){% endif %}
+{% for section in release.sections -%}
 {% for change in section.changes | reverse -%}
-- {{ change.description }}{% if change.scope %}{{ change.scope }}{% endif %}
+- {{ change.description | regex_replace("\\s+\\(#(\\d+)\\)$", "") }}{% if change.scope %}{{ change.scope }}{% endif %}
 {% endfor %}{% endfor %}
 {% endfor %}


### PR DESCRIPTION
This change adopts the release note style used in OpoLua and Reconnect, dropping the distinction between types of changes and adding links to GitHub releases.

Preparatory work for shipping releases outside of the App Store.