### PR TITLE
fix: ✨ Show update menu item in standalone release

### DIFF
--- a/macos/Thoughts/Model/ApplicationModel.swift
+++ b/macos/Thoughts/Model/ApplicationModel.swift
@@ -116,6 +116,13 @@ class ApplicationModel: NSObject {
         self.start()
     }
 
+    var isAppStoreRelease: Bool = {
+        guard let appStoreReceiptURL = Bundle.main.appStoreReceiptURL else {
+            return false
+        }
+        return FileManager.default.fileExists(atPath: appStoreReceiptURL.path)
+    }()
+
     @MainActor private func start() {
 
         // Watch the document for changes, debounce, and save changes to disk.
@@ -148,7 +155,7 @@ class ApplicationModel: NSObject {
         }
 
 #if !DEBUG
-        if Bundle.main.appStoreReceiptURL == nil {
+        if !isAppStoreRelease {
             updaterController.startUpdater()
         }
 #endif

--- a/macos/Thoughts/ThoughtsApp.swift
+++ b/macos/Thoughts/ThoughtsApp.swift
@@ -51,7 +51,7 @@ struct ThoughtsApp: App {
         }
         .commands {
             ThoughtsCommands(applicationModel: applicationModel)
-            if Bundle.main.appStoreReceiptURL == nil {
+            if !applicationModel.isAppStoreRelease {
                 UpdateCommands(updater: applicationModel.updaterController.updater)
             }
         }

--- a/macos/Thoughts/Views/Menu/MainMenu.swift
+++ b/macos/Thoughts/Views/Menu/MainMenu.swift
@@ -54,7 +54,7 @@ struct MainMenu: View {
 
         Divider()
 
-        if Bundle.main.appStoreReceiptURL == nil {
+        if !applicationModel.isAppStoreRelease {
 
             UpdateLink(updater: applicationModel.updaterController.updater)
 


### PR DESCRIPTION
The App Store detection code wasn’t working correctly, meaning we never showed the Sparkle update menu item.
