### PR TITLE
ci: Ensure the website build runs after any release steps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,8 @@ jobs:
 
   website-build:
 
+    needs: [macos-build]
+
     runs-on: ubuntu-latest
 
     steps:
@@ -88,23 +90,20 @@ jobs:
     needs: website-build
     if: ${{ github.ref == 'refs/heads/main' }}
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
 
-    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step
     runs-on: ubuntu-latest
 
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 # or the latest "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@v4
 
   sparkle-update:
     needs: macos-build


### PR DESCRIPTION
Without this, it's possible for the release list to be out of date at the end of a build.
