### PR TITLE
fix: 🩵 Use the Thoughts accent color for links

### DIFF
--- a/macos/Thoughts.xcodeproj/project.pbxproj
+++ b/macos/Thoughts.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		D804FB112C081A2F004F8666 /* FrontmatterSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D804FB102C081A2F004F8666 /* FrontmatterSwift */; };
 		D8296CEE2E29EBBF005088B6 /* ThoughtsCore in Frameworks */ = {isa = PBXBuildFile; productRef = D8296CED2E29EBBF005088B6 /* ThoughtsCore */; };
 		D87707B52C01592400362786 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = D87707B42C01592400362786 /* HotKey */; };
-		D8BA4D492BE59E16001A2A26 /* HighlightedTextEditor in Frameworks */ = {isa = PBXBuildFile; productRef = D8BA4D482BE59E16001A2A26 /* HighlightedTextEditor */; };
 		D8C283E92BD9954F00161C82 /* HashRainbow in Frameworks */ = {isa = PBXBuildFile; productRef = D8C283E82BD9954F00161C82 /* HashRainbow */; };
 		D8F06D4B2B67275B0039AEF4 /* Diligence in Frameworks */ = {isa = PBXBuildFile; productRef = D8F06D4A2B67275B0039AEF4 /* Diligence */; };
 /* End PBXBuildFile section */
@@ -62,7 +61,6 @@
 			files = (
 				D8C283E92BD9954F00161C82 /* HashRainbow in Frameworks */,
 				D804FB112C081A2F004F8666 /* FrontmatterSwift in Frameworks */,
-				D8BA4D492BE59E16001A2A26 /* HighlightedTextEditor in Frameworks */,
 				D8296CEE2E29EBBF005088B6 /* ThoughtsCore in Frameworks */,
 				D8F06D4B2B67275B0039AEF4 /* Diligence in Frameworks */,
 				D87707B52C01592400362786 /* HotKey in Frameworks */,
@@ -137,7 +135,6 @@
 			packageProductDependencies = (
 				D8F06D4A2B67275B0039AEF4 /* Diligence */,
 				D8C283E82BD9954F00161C82 /* HashRainbow */,
-				D8BA4D482BE59E16001A2A26 /* HighlightedTextEditor */,
 				D87707B42C01592400362786 /* HotKey */,
 				D804FB102C081A2F004F8666 /* FrontmatterSwift */,
 				D8296CED2E29EBBF005088B6 /* ThoughtsCore */,
@@ -223,7 +220,6 @@
 			packageReferences = (
 				D8F06D492B67275B0039AEF4 /* XCLocalSwiftPackageReference "dependencies/diligence" */,
 				D8C283E72BD9954F00161C82 /* XCRemoteSwiftPackageReference "HashRainbow" */,
-				D8BA4D472BE59DC5001A2A26 /* XCLocalSwiftPackageReference "dependencies/HighlightedTextEditor" */,
 				D87707B32C01592400362786 /* XCRemoteSwiftPackageReference "HotKey" */,
 				D8296CEC2E29EBBF005088B6 /* XCLocalSwiftPackageReference "ThoughtsCore" */,
 			);
@@ -612,10 +608,6 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ThoughtsCore;
 		};
-		D8BA4D472BE59DC5001A2A26 /* XCLocalSwiftPackageReference "dependencies/HighlightedTextEditor" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = dependencies/HighlightedTextEditor;
-		};
 		D8F06D492B67275B0039AEF4 /* XCLocalSwiftPackageReference "dependencies/diligence" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = dependencies/diligence;
@@ -654,11 +646,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D87707B32C01592400362786 /* XCRemoteSwiftPackageReference "HotKey" */;
 			productName = HotKey;
-		};
-		D8BA4D482BE59E16001A2A26 /* HighlightedTextEditor */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D8BA4D472BE59DC5001A2A26 /* XCLocalSwiftPackageReference "dependencies/HighlightedTextEditor" */;
-			productName = HighlightedTextEditor;
 		};
 		D8C283E82BD9954F00161C82 /* HashRainbow */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/macos/Thoughts/Views/Compose/ComposeView.swift
+++ b/macos/Thoughts/Views/Compose/ComposeView.swift
@@ -52,7 +52,7 @@ struct ComposeView: View {
     var body: some View {
         @Bindable var applicationModel = applicationModel
         VStack(spacing: 0) {
-            HighlightedTextEditor(text: $applicationModel.document.content, highlightRules: .markdown)
+            HighlightedTextEditor(text: $applicationModel.document.content, highlightRules: .thoughtsMarkdown)
                 .frame(minWidth: 400)
                 .edgesIgnoringSafeArea(.all)
                 .focused($focus, equals: .text)

--- a/macos/ThoughtsCore/Package.swift
+++ b/macos/ThoughtsCore/Package.swift
@@ -15,9 +15,10 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "./../dependencies/diligence"),
+        .package(path: "./../dependencies/FrontmatterSwift"),
+        .package(path: "./../dependencies/HighlightedTextEditor"),
         .package(path: "./../dependencies/interact"),
         .package(path: "./../dependencies/TagField"),
-        .package(path: "./../dependencies/FrontmatterSwift"),
         .package(url: "https://github.com/sparkle-project/Sparkle", .upToNextMajor(from: "2.7.1")),
         .package(url: "https://github.com/inseven/glitter.git", .upToNextMajor(from: "0.1.3")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "5.1.2")),
@@ -27,9 +28,10 @@ let package = Package(
             name: "ThoughtsCore",
             dependencies: [
                 .product(name: "Diligence", package: "diligence"),
+                .product(name: "FrontmatterSwift", package: "FrontmatterSwift"),
+                .product(name: "HighlightedTextEditor", package: "HighlightedTextEditor"),
                 .product(name: "Interact", package: "interact"),
                 .product(name: "TagField", package: "TagField"),
-                .product(name: "FrontmatterSwift", package: "FrontmatterSwift"),
                 .product(name: "Sparkle", package: "Sparkle", condition: .when(platforms: [.macOS])),
                 .product(name: "Glitter", package: "glitter", condition: .when(platforms: [.macOS])),
                 .product(name: "Yams", package: "Yams"),

--- a/macos/ThoughtsCore/Package_App_Store.swift
+++ b/macos/ThoughtsCore/Package_App_Store.swift
@@ -15,9 +15,10 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "./../dependencies/diligence"),
+        .package(path: "./../dependencies/FrontmatterSwift"),
+        .package(path: "./../dependencies/HighlightedTextEditor"),
         .package(path: "./../dependencies/interact"),
         .package(path: "./../dependencies/TagField"),
-        .package(path: "./../dependencies/FrontmatterSwift"),
         .package(url: "https://github.com/sparkle-project/Sparkle", .upToNextMajor(from: "2.7.1")),
         .package(url: "https://github.com/inseven/glitter.git", .upToNextMajor(from: "0.1.3")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "5.1.2")),
@@ -27,9 +28,10 @@ let package = Package(
             name: "ThoughtsCore",
             dependencies: [
                 .product(name: "Diligence", package: "diligence"),
+                .product(name: "FrontmatterSwift", package: "FrontmatterSwift"),
+                .product(name: "HighlightedTextEditor", package: "HighlightedTextEditor"),
                 .product(name: "Interact", package: "interact"),
                 .product(name: "TagField", package: "TagField"),
-                .product(name: "FrontmatterSwift", package: "FrontmatterSwift"),
                 .product(name: "Yams", package: "Yams"),
             ],
             resources: [

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Color.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Color.swift
@@ -1,0 +1,29 @@
+// Copyright (c) 2021-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+extension Color {
+
+    var nativeColor: NativeColor {
+        return NativeColor(self)
+    }
+
+}

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/NSColor.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/NSColor.swift
@@ -1,0 +1,31 @@
+// Copyright (c) 2021-2026 Jason Morley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if os(macOS)
+
+import SwiftUI
+
+extension NSColor {
+
+    static let accentColor = NSColor(Color("AccentColor", bundle: .main))
+
+}
+
+#endif

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Sequence.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Sequence.swift
@@ -36,8 +36,8 @@ private let htmlRegex = try! NSRegularExpression(
 )
 
 #if os(macOS)
-let defaultEditorFont = NSFont.monospacedSystemFont(ofSize: 14.0, weight: .regular)
-let codeFont = NSFont.monospacedSystemFont(ofSize: 14.0, weight: .thin)
+nonisolated(unsafe) let defaultEditorFont = NSFont.monospacedSystemFont(ofSize: 14.0, weight: .regular)
+nonisolated(unsafe) let codeFont = NSFont.monospacedSystemFont(ofSize: 14.0, weight: .thin)
 let headingTraits: NSFontDescriptor.SymbolicTraits = [.bold, .expanded]
 let boldTraits: NSFontDescriptor.SymbolicTraits = [.bold]
 let emphasisTraits: NSFontDescriptor.SymbolicTraits = [.italic]
@@ -79,7 +79,7 @@ public extension Sequence where Iterator.Element == HighlightRule {
                 pattern: linkOrImageRegex,
                 formattingRules: [
                     TextFormattingRule(fontTraits: boldTraits),
-                    TextFormattingRule(key: .foregroundColor, value: NSColor.systemBlue),
+                    TextFormattingRule(key: .foregroundColor, value: Color.accentColor),
                 ]
             ),
             HighlightRule(

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Sequence.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Sequence.swift
@@ -60,7 +60,8 @@ let textColor = UIColor.label
 private let maxHeadingLevel = 6
 
 public extension Sequence where Iterator.Element == HighlightRule {
-    static var markdown: [HighlightRule] {
+
+    static var thoughtsMarkdown: [HighlightRule] {
         [
             HighlightRule(pattern: .all, formattingRule: TextFormattingRule(key: .font, value: defaultEditorFont)),
             HighlightRule(pattern: inlineCodeRegex, formattingRule: TextFormattingRule(key: .font, value: codeFont)),
@@ -79,7 +80,7 @@ public extension Sequence where Iterator.Element == HighlightRule {
                 pattern: linkOrImageRegex,
                 formattingRules: [
                     TextFormattingRule(fontTraits: boldTraits),
-                    TextFormattingRule(key: .foregroundColor, value: Color.accentColor),
+                    TextFormattingRule(key: .foregroundColor, value: NSColor.accentColor),
                 ]
             ),
             HighlightRule(

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Sequence.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Extensions/Sequence.swift
@@ -80,7 +80,7 @@ public extension Sequence where Iterator.Element == HighlightRule {
                 pattern: linkOrImageRegex,
                 formattingRules: [
                     TextFormattingRule(fontTraits: boldTraits),
-                    TextFormattingRule(key: .foregroundColor, value: NSColor.accentColor),
+                    TextFormattingRule(key: .foregroundColor, value: Color("AccentColor", bundle: .main).nativeColor),
                 ]
             ),
             HighlightRule(

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Model/NativeColor.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Model/NativeColor.swift
@@ -20,12 +20,14 @@
 
 #if os(macOS)
 
-import SwiftUI
+import AppKit
 
-extension NSColor {
+typealias NativeColor = NSColor
 
-    static let accentColor = NSColor(Color("AccentColor", bundle: .main))
+#else
 
-}
+import UIKit
+
+typealias NativeColor = UIColor
 
 #endif


### PR DESCRIPTION
This includes a drive-by refactor to move `Sequence` into ThoughtsCore.