### PR TITLE
refactor: Move the compose views into ThoughtsCore

### DIFF
--- a/macos/Thoughts/Views/Compose/ComposeWindow.swift
+++ b/macos/Thoughts/Views/Compose/ComposeWindow.swift
@@ -24,13 +24,11 @@ import ThoughtsCore
 
 struct ComposeWindow: Scene {
 
-    @Environment(ApplicationModel.self) var applicationModel: ApplicationModel
-
     static let windowID = "compose-window"
 
     var body: some Scene {
         Window("Thoughts", id: Self.windowID) {
-            ContentView(applicationModel: applicationModel)
+            ContentView()
         }
     }
 

--- a/macos/Thoughts/Views/Introduction/IntroductionView.swift
+++ b/macos/Thoughts/Views/Introduction/IntroductionView.swift
@@ -28,7 +28,7 @@ struct IntroductionView: View {
 
     @Environment(\.closeWindow) private var closeWindow
 
-    let applicationModel: ApplicationModel
+    @Environment(ApplicationModel.self) private var applicationModel
 
     enum PageIdentifier: Identifiable {
 

--- a/macos/Thoughts/Views/Introduction/NSIntroductionWindow.swift
+++ b/macos/Thoughts/Views/Introduction/NSIntroductionWindow.swift
@@ -25,7 +25,8 @@ import ThoughtsCore
 class NSIntroductionWindow: NSWindow {
 
     convenience init(applicationModel: ApplicationModel) {
-        self.init(contentViewController: NSHostingController(rootView: IntroductionView(applicationModel: applicationModel)))
+        self.init(contentViewController: NSHostingController(rootView: IntroductionView()
+            .environment(applicationModel)))
         self.title = "Welcome to Thoughts"
         self.titleVisibility = .hidden
         self.titlebarAppearsTransparent = true

--- a/macos/ThoughtsCore/Package.swift
+++ b/macos/ThoughtsCore/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 
@@ -6,7 +6,7 @@ let package = Package(
     name: "ThoughtsCore",
     platforms: [
         .macOS(.v14),
-        .iOS(.v18),
+        .iOS(.v26),
     ],
     products: [
         .library(

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Views/Compose/ComposeView.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Views/Compose/ComposeView.swift
@@ -24,8 +24,6 @@ import Combine
 import HighlightedTextEditor
 import TagField
 
-import ThoughtsCore
-
 struct ComposeView: View {
 
     enum Focus {

--- a/macos/ThoughtsCore/Sources/ThoughtsCore/Views/Compose/ContentView.swift
+++ b/macos/ThoughtsCore/Sources/ThoughtsCore/Views/Compose/ContentView.swift
@@ -20,11 +20,9 @@
 
 import SwiftUI
 
-import ThoughtsCore
+public struct ContentView: View {
 
-struct ContentView: View {
-
-    var applicationModel: ApplicationModel
+    @Environment(ApplicationModel.self) private var applicationModel
 
     @MainActor var systemImage: String {
         if applicationModel.shouldSaveLocation {
@@ -38,7 +36,10 @@ struct ContentView: View {
         }
     }
 
-    var body: some View {
+    public init() {
+    }
+
+    public var body: some View {
         HStack {
             if applicationModel.rootURL != nil {
                 ComposeView(applicationModel: applicationModel)
@@ -62,13 +63,12 @@ struct ContentView: View {
                 } label: {
                     let hasLocation = applicationModel.document.location != nil
                     Label("Use Location", systemImage: systemImage)
-                        .foregroundColor(hasLocation ? .accent : nil)
+                        .foregroundColor(hasLocation ? .accentColor : nil)
                         .symbolEffect(.pulse, isActive: applicationModel.shouldSaveLocation && applicationModel.document.location == nil)
                 }
                 .disabled(applicationModel.rootURL == nil)
             }
         }
     }
-
 
 }


### PR DESCRIPTION
This includes a drive-by fix to inject the application model as an environment variable.
