### PR TITLE
docs(website): 🔗 Move the 'More' link into the top navigation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,4 @@
 [submodule "docs/_theme"]
 	path = docs/_theme
 	url = https://github.com/jbmorley/showcase-theme.git
+	branch = main

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,6 +17,8 @@ navigation:
     href: https://github.com/inseven/thoughts
   - title: Donate
     href: https://jbmorley.co.uk/support/
+  - title: More
+    href: https://jbmorley.co.uk/software/
 
 footer:
   - title: Privacy Policy
@@ -25,8 +27,6 @@ footer:
     href: /support
   - title: License
     href: /license
-  - title: More Software
-    href: https://jbmorley.co.uk/software/
 
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Includes a drive-by fix to specify the 'main' branch for the theme submodule.
